### PR TITLE
Use Mapbox API v4

### DIFF
--- a/Leaflet.MakiMarkers.js
+++ b/Leaflet.MakiMarkers.js
@@ -3,9 +3,10 @@
  *
  * References:
  *   Maki Icons: https://www.mapbox.com/maki/
- *   MapBox Marker API: https://www.mapbox.com/developers/api/static/#markers
+ *   Mapbox Marker API: https://www.mapbox.com/api-documentation/#retrieve-a-standalone-marker
  *
  * Usage:
+ *   L.MakiMarkers.accessToken = "<YOUR_ACCESS_TOKEN>";
  *   var icon = L.MakiMarkers.icon({icon: "rocket", color: "#b0b", size: "m"});
  *
  * License:
@@ -32,6 +33,7 @@
       "swimming","telephone","tennis","theatre","toilets","town-hall","town","triangle-stroked",
       "triangle","village","warehouse","waste-basket","water","wetland","zoo"
     ],
+    accessToken: null,
     defaultColor: "#0a0",
     defaultIcon: "circle-stroked",
     defaultSize: "m",
@@ -49,8 +51,6 @@
       popupAnchor: [0,-40]
     }
   };
-
-  L.MakiMarkers.accessToken = null;
 
   L.MakiMarkers.Icon = L.Icon.extend({
     options: {
@@ -94,7 +94,6 @@
           break;
       }
 
-
       pin = "pin-" + options.size;
 
       if (options.icon !== null) {
@@ -108,8 +107,6 @@
 
         pin += "+" + options.color;
       }
-
-
 
       options.iconUrl = "" + L.MakiMarkers.apiUrl + pin +  ".png" + tokenQuery;
       options.iconRetinaUrl = L.MakiMarkers.apiUrl + pin + "@2x.png" + tokenQuery;

--- a/Leaflet.MakiMarkers.js
+++ b/Leaflet.MakiMarkers.js
@@ -35,7 +35,7 @@
     defaultColor: "#0a0",
     defaultIcon: "circle-stroked",
     defaultSize: "m",
-    apiUrl: "https://api.tiles.mapbox.com/v3/marker/",
+    apiUrl: "https://api.mapbox.com/v4/marker/",
     smallOptions: {
       iconSize: [20, 50],
       popupAnchor: [0,-20]
@@ -50,8 +50,13 @@
     }
   };
 
+  L.MakiMarkers.accessToken = null;
+
   L.MakiMarkers.Icon = L.Icon.extend({
     options: {
+      //Mapbox API access token, see https://www.mapbox.com/api-documentation/?language=CLI#access-tokens
+      //Instead of setting with each icon, you can set globally as L.MakiMarkers.accessToken
+      accessToken: null,
       //Maki icon: any from https://www.mapbox.com/maki/ (ref: L.MakiMarkers.icons)
       icon: L.MakiMarkers.defaultIcon,
       //Marker color: short or long form hex color code
@@ -66,7 +71,14 @@
 
     initialize: function(options) {
       var pin;
+      var tokenQuery;
 
+      var accessToken = options.accessToken || L.MakiMarkers.accessToken;
+      if (!accessToken) {
+        throw new Error("Access to the Mapbox API requires a valid access token.");
+      }
+
+      tokenQuery = "?access_token=" + accessToken;
       options = L.setOptions(this, options);
 
       switch (options.size) {
@@ -97,8 +109,10 @@
         pin += "+" + options.color;
       }
 
-      options.iconUrl = "" + L.MakiMarkers.apiUrl + pin +  ".png";
-      options.iconRetinaUrl = L.MakiMarkers.apiUrl + pin + "@2x.png";
+
+
+      options.iconUrl = "" + L.MakiMarkers.apiUrl + pin +  ".png" + tokenQuery;
+      options.iconRetinaUrl = L.MakiMarkers.apiUrl + pin + "@2x.png" + tokenQuery;
     }
   });
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # Leaflet.MakiMarkers
 
-[Leaflet](http://www.leafletjs.com) plugin to create map icons using [Maki Icons](https://www.mapbox.com/maki/) from Mapbox. Markers are retrieved from Mapbox's [Static Marker API](https://www.mapbox.com/developers/api/static/#markers).
+[Leaflet](http://www.leafletjs.com) plugin to create map icons using [Maki Icons](https://www.mapbox.com/maki/) from Mapbox. Markers are retrieved from Mapbox's [Static Marker API](https://www.mapbox.com/api-documentation/#retrieve-a-standalone-marker).
 
-[![Screenshot](https://raw.github.com/jseppi/Leaflet.MakiMarkers/master/images/screenshot.png "Screenshot of MakiMarkers")](http://jsfiddle.net/Zhzvp/)
+[![Screenshot](https://raw.github.com/jseppi/Leaflet.MakiMarkers/master/images/screenshot.png "Screenshot of MakiMarkers")]
 
 ## Usage
 
-Simply include `Leaflet.MakiMarkers.js` in your page after you include `Leaflet.js`: `<script src="Leaflet.MakiMarkers.js"></script>`
+Include `Leaflet.MakiMarkers.js` in your page after you include `Leaflet.js`: `<script src="Leaflet.MakiMarkers.js"></script>`
+
+The most recent version of Mapbox's static API (v4) requires that a valid access token be specified with every request. Please see https://www.mapbox.com/api-documentation/?language=CLI#access-tokens for more information.
 
 ```js
-//First, specify a valid Mapbox API access token (see https://www.mapbox.com/api-documentation/?language=CLI#access-tokens)
+//First, specify your Mapbox API access token
 L.MakiMarkers.accessToken = "<YOUR_ACCESS_TOKEN>";
 
 // Specify a Maki icon name, hex color, and size (s, m, or l).
@@ -19,8 +21,6 @@ L.MakiMarkers.accessToken = "<YOUR_ACCESS_TOKEN>";
 var icon = L.MakiMarkers.icon({icon: "rocket", color: "#b0b", size: "m"});
 L.marker([30.287, -97.72], {icon: icon}).addTo(map);
 ```
-
-[JSFiddle Demo](http://jsfiddle.net/Zhzvp/26/)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@
 Simply include `Leaflet.MakiMarkers.js` in your page after you include `Leaflet.js`: `<script src="Leaflet.MakiMarkers.js"></script>`
 
 ```js
+//First, specify a valid Mapbox API access token (see https://www.mapbox.com/api-documentation/?language=CLI#access-tokens)
+L.MakiMarkers.accessToken = "<YOUR_ACCESS_TOKEN>";
+
 // Specify a Maki icon name, hex color, and size (s, m, or l).
 // An array of icon names can be found in L.MakiMarkers.icons or at https://www.mapbox.com/maki/
 // Lowercase letters a-z and digits 0-9 can also be used. A value of null will result in no icon.

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "Leaflet.MakiMarkers",
   "main": "Leaflet.MakiMarkers.js",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "homepage": "https://github.com/jseppi/Leaflet.MakiMarkers",
   "authors": [
     "James Seppi <james.seppi@gmail.com>"

--- a/index.html
+++ b/index.html
@@ -15,6 +15,13 @@
     <div id="map" style="width: 600px; height: 400px"></div>
 
     <script>
+        //Request access token (see https://www.mapbox.com/api-documentation/?language=CLI#access-tokens)
+        var accessToken = prompt("Please enter your Mapbox API access token");
+        if (!accessToken) {
+            alert("Valid Mapbox API access token is required");
+        }
+        L.MakiMarkers.accessToken = accessToken;
+
         var map = L.map('map').setView([30.289, -97.74], 12);
 
         L.tileLayer('http://{s}.mqcdn.com/tiles/1.0.0/map/{z}/{x}/{y}.png', {


### PR DESCRIPTION
The previously used v3 API is deprecated. This switches Leaflet.MakiMarkers to use the newer v4 API. Unfortunately v4 requires a valid Mapbox API token with every request. Version 2.0.0 of Leaflet.MakiMarkers allows the developer to specify an accessToken via `L.MakiMarkers.accessToken` or with each icon as part of the config object in the `L.MakiMarkers.icon(confg)` constructor.